### PR TITLE
minor changes to help review

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,16 +6,19 @@ import os
 class DevilConan(ConanFile):
     name = "DevIL"
     version = "1.8.0"
+    homepage = "https://github.com/DentonW/DevIL"
+    description = ("Developer's Image Library (DevIL) is a cross-platform image library utilizing a simple syntax "
+                   "to load, save, convert, manipulate, filter, and display a variety of images with ease. "
+                   "It is highly portable and has been ported to several platforms.")
     license = "LGPL License http://openil.sourceforge.net/license.php"
     url = "https://github.com/whitebatman2/conan-devil"
-    requires = "zlib/1.2.8@lasote/stable", "libpng/1.6.21@lasote/stable", "libtiff/4.0.6@bilke/stable", "libjpeg/9a@Kaosumaru/stable"
+    requires = "zlib/1.2.11@conan/stable", "libpng/1.6.21@lasote/stable", "libtiff/4.0.6@bilke/stable", "libjpeg/9a@Kaosumaru/stable"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False]}
-    default_options = "shared=True", "zlib:shared=True", "libpng:shared=True"
+    default_options = "shared=False"
     generators = "cmake"
 
     def source(self):
-
         zip_name = "v%s.zip" % self.version
         download("https://github.com/DentonW/DevIL/archive/%s" % zip_name, zip_name, verify=True)
         unzip(zip_name)


### PR DESCRIPTION
I have started to review for inclusion in conan-center.

The recipe looks good, but there are a few issues:
- The dependencies for imaging (jpeg, etc) are still not in conan-center. We need to review and include them first in order to include this one. Actually some of the dependencies are broken in conan 1.0
- The one that is already there is ``zlib/1.2.11@conan/stable``, I have updated it.
- It is necessary to setup CI to create binary packages for some configurations. It is not difficult with travis/appveyor, conan has some utilities, I can help with that too.
- I have suggested to use ``shared=False`` as the default mode, most libraries in conan (and also the default of systems as CMake) is static libraries.
- I have added some metadata.

I'll follow up when we have the dependencies already in conan-center, this library indeeds look very interesting and useful. Many thanks!

